### PR TITLE
 Post-v0.1.7 Fixes, Updates and Enhancements (Rollback dependabot)

### DIFF
--- a/openlibrarian_root/requirements.txt
+++ b/openlibrarian_root/requirements.txt
@@ -14,7 +14,7 @@ channels==4.1.0
 charset-normalizer==3.3.2
 constantly==23.10.4
 coverage==7.6.7
-cryptography==44.0.1
+cryptography==43.0.1
 daphne==4.1.2
 Django==5.0.11
 django-async==0.7.3


### PR DESCRIPTION
- Roll back up version for "cryptography" package until conflict with dependencies is resolved.

requested cryptography==44.0.1
autobahn 24.4.2 depends on cryptography>=3.4.6
pyopenssl 24.2.1 depends on cryptography<44 and >=41.0.5